### PR TITLE
Closes #14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Adds support for additional source vocabularies to the `rxnorm` sub-command using the `-v` option
+- Adds support for additional suppress flag filtering to the `rxnorm` sub-command using the `-s` option
+
 ## 0.7.0
 
-## Added
+### Added
 
 - Adds a new sub-command: `gsea`
 

--- a/termlink/__main__.py
+++ b/termlink/__main__.py
@@ -106,6 +106,13 @@ parser_rxnorm.add_argument(
     help="resource identifier for files"
 )
 
+parser_rxnorm.add_argument(
+    "-s",
+    "--source",
+    action='append',
+    default=['RXNORM']
+)
+
 parser_rxnorm.set_defaults(execute=RxNormCommand.execute)
 
 args = parser.parse_args()

--- a/termlink/__main__.py
+++ b/termlink/__main__.py
@@ -94,6 +94,14 @@ parser_rxnorm = subparsers.add_parser(
     Gold Standard Drug Database, and Multum. By providing links between these 
     vocabularies, RxNorm can mediate messages between systems not using the 
     same software and vocabulary. [1] 
+
+    Additional source vocabularies, aside from RxNorm, must be specified using 
+    the --vocabulary option. The full list of available source vocabularies is 
+    available at https://www.nlm.nih.gov/research/umls/rxnorm/docs/2019/rxnorm_doco_full_2019-1.html#s3_0.
+
+    By default concepts that are not suppressed, specified by the 'N' flag, are
+    included in the output. Additional flags can be included using the --suppress
+    option. More information on suppression can is documented at https://www.nlm.nih.gov/research/umls/rxnorm/docs/2019/rxnorm_doco_full_2019-1.html#s12_0.
     """,
     epilog="""
     [1] RxNorm. Retrieved April 22, 2019, from https://www.nlm.nih.gov/research/umls/rxnorm/
@@ -107,10 +115,19 @@ parser_rxnorm.add_argument(
 )
 
 parser_rxnorm.add_argument(
-    "-s",
-    "--source",
+    "-v",
+    "--vocabulary",
     action='append',
-    default=['RXNORM']
+    default=['RXNORM'],
+    help="use an additional source vocabulary (default: 'RXNORM')"
+)
+
+parser_rxnorm.add_argument(
+    "-s",
+    "--suppress",
+    action='append',
+    default=['N'],
+    help="unset the provided suppress flag (default: 'N')"
 )
 
 parser_rxnorm.set_defaults(execute=RxNormCommand.execute)

--- a/termlink/rxnorm.py
+++ b/termlink/rxnorm.py
@@ -21,7 +21,6 @@ _RXNCONSO_FIELDS = ["RXCUI", "LAT", "TS", "LUI", "STT", "SUI", "ISPREF", "RXAUI"
 _RXNREL_FIELDS = ["RXCUI1", "RXAUI1", "STYPE1", "REL", "RXCUI2", "RXAUI2",
                   "STYPE2", "RELA", "RUI", "SRUI", "SAB", "SL", "DIR", "RG", "SUPPRESS", "CVF", ]
 
-
 def _to_system(sab):
     """Converts an SAB to a system
 
@@ -111,7 +110,7 @@ class Service(RelationshipService):
             .fromcsv(path, delimiter='|') \
             .setheader(_RXNCONSO_FIELDS) \
             .select(lambda rec: rec['SAB'] == 'RXNORM') \
-            .cut('RXCUI', 'CODE', 'STR')
+            .cut('RXCUI', 'CODE', 'STR', 'SAB')
 
         source = rxnconso.prefixheader('source.')
         target = rxnconso.prefixheader('target.')

--- a/termlink/rxnorm.py
+++ b/termlink/rxnorm.py
@@ -140,6 +140,7 @@ class Service:
             .fromcsv(path, delimiter='|') \
             .setheader(_RXNCONSO_FIELDS) \
             .select(lambda rec: rec['SAB'] in self.sources) \
+            .select(lambda rec: rec['SUPPRESS'] is 'N') \
             .cut('RXCUI', 'CODE', 'STR', 'SAB')
 
         source = rxnconso.prefixheader('source.')

--- a/termlink/rxnorm.py
+++ b/termlink/rxnorm.py
@@ -25,6 +25,11 @@ _RELATIONSHIP_TO_EQUIVALENCE = {
     'RB': 'subsumes',
 }
 
+_SAB_TO_SYSTEM = {
+    'ATC': 'http://www.whocc.no/atc',
+    'CVX': 'http://hl7.org/fhir/sid/cvx',
+    'SNOMEDCT_US': 'http://snomed.info/sct',
+}
 
 def _to_equivalence(rel):
     """Converts a relationship into an equivalence
@@ -42,7 +47,7 @@ def _to_equivalence(rel):
 
 
 def _to_system(sab):
-    """Converts an SAB to a system
+    """Converts an SAB to a system.
 
     Args:
         sab: a UMLS source name abbreviation
@@ -50,7 +55,7 @@ def _to_system(sab):
     Returns:
         the identity of the terminology system
     """
-    return "http://www.nlm.nih.gov/research/umls/%s" % sab.lower()
+    return _SAB_TO_SYSTEM.get(sab, 'http://www.nlm.nih.gov/research/umls/%s' % sab.lower())
 
 
 def _to_relationship(rec):

--- a/termlink/rxnorm.py
+++ b/termlink/rxnorm.py
@@ -88,10 +88,10 @@ class Command(SubCommand):
         etl.io.totext(table, encoding='utf8', template='{relationship}\n')
 
 
-class Service(RelationshipService):
+class Service:
     """Converts the RxNorm database"""
 
-    def __init__(self, uri):
+    def __init__(self, uri, sources=['RXNORM']):
         """Bootstraps a service
 
         Args:
@@ -102,6 +102,7 @@ class Service(RelationshipService):
             raise ValueError("'uri.scheme' %s not supported" % uri.scheme)
 
         self.uri = uri
+        self.sources = set(sources)
 
     def get_relationships(self):
         "Parses a list of `Relationship` objects."
@@ -109,7 +110,7 @@ class Service(RelationshipService):
         rxnconso = etl \
             .fromcsv(path, delimiter='|') \
             .setheader(_RXNCONSO_FIELDS) \
-            .select(lambda rec: rec['SAB'] == 'RXNORM') \
+            .select(lambda rec: rec['SAB'] in self.sources) \
             .cut('RXCUI', 'CODE', 'STR', 'SAB')
 
         source = rxnconso.prefixheader('source.')
@@ -119,7 +120,7 @@ class Service(RelationshipService):
         rxnrel = etl \
             .fromcsv(path, delimiter='|') \
             .setheader(_RXNREL_FIELDS) \
-            .select(lambda rec: rec['SAB'] == 'RXNORM') \
+            .select(lambda rec: rec['SAB'] in self.sources) \
             .select(lambda rec: rec['STYPE1'] == 'CUI') \
             .select(lambda rec: rec['STYPE2'] == 'CUI') \
             .select(lambda rec: rec['REL'] == 'RB') \

--- a/tests/rxnorm_test.py
+++ b/tests/rxnorm_test.py
@@ -71,7 +71,8 @@ def test_to_json():
 
     src = Record(values, fields)
     res = _to_json(src)
-    ok_(res[0])
+    print(res)
+    ok_(False)
 
 
 def test_to_system():

--- a/tests/rxnorm_test.py
+++ b/tests/rxnorm_test.py
@@ -22,9 +22,11 @@ def test_service_uri_requires_scheme_file():
     uri = urlparse("foobar://")
     Service(uri=uri)
 
+
 def test_to_relationship():
     """Checks that a record is properly converted to a Relationship"""
-    fields = ['REL', 'source.CODE', 'source.STR', 'source.SAB', 'target.CODE', 'target.STR', 'target.SAB']
+    fields = ['REL', 'source.CODE', 'source.STR', 'source.SAB',
+              'target.CODE', 'target.STR', 'target.SAB']
     values = (
         'RB',
         '313782',
@@ -54,11 +56,11 @@ def test_to_relationship():
     eq_(exp, res)
 
 
-
 def test_to_json():
     """Checks that a record is properly converted to .json"""
 
-    fields = ['REL', 'source.CODE', 'source.STR', 'source.SAB', 'target.CODE', 'target.STR', 'target.SAB']
+    fields = ['REL', 'source.CODE', 'source.STR', 'source.SAB',
+              'target.CODE', 'target.STR', 'target.SAB']
     values = (
         'RB',
         '313782',

--- a/tests/rxnorm_test.py
+++ b/tests/rxnorm_test.py
@@ -6,7 +6,8 @@ from nose.tools import ok_, raises, eq_
 
 from petl import Record
 
-from termlink.rxnorm import Service, _to_json
+from termlink.models import Coding, Relationship
+from termlink.rxnorm import Service, _to_json, _to_system, _to_relationship
 
 
 def test_service_uri_can_be_file():
@@ -21,18 +22,61 @@ def test_service_uri_requires_scheme_file():
     uri = urlparse("foobar://")
     Service(uri=uri)
 
+def test_to_relationship():
+    """Checks that a record is properly converted to a Relationship"""
+    fields = ['source.CODE', 'source.STR', 'source.SAB',
+              'target.CODE', 'target.STR', 'target.SAB']
+    values = (
+        '313782',
+        'Acetaminophen 325 MG Oral Tablet',
+        'RXNORM',
+        '1152843',
+        'Acetaminophen Pill',
+        'RXNORM'
+    )
+
+    rec = Record(values, fields)
+    res = _to_relationship(rec)
+    exp = Relationship(
+        equivalence='subsumes',
+        source=Coding(
+            system='http://www.nlm.nih.gov/research/umls/rxnorm',
+            code='313782',
+            display='Acetaminophen 325 MG Oral Tablet'
+        ),
+        target=Coding(
+            system='http://www.nlm.nih.gov/research/umls/rxnorm',
+            code='1152843',
+            display='Acetaminophen Pill'
+        )
+    )
+
+    eq_(exp, res)
+
+
 
 def test_to_json():
     """Checks that a record is properly converted to .json"""
 
-    fields = ['source.CODE', 'source.STR', 'target.CODE', 'target.STR']
+    fields = ['source.CODE', 'source.STR', 'source.SAB',
+              'target.CODE', 'target.STR', 'target.SAB']
     values = (
         '313782',
         'Acetaminophen 325 MG Oral Tablet',
+        'RXNORM',
         '1152843',
-        'Acetaminophen Pill'
+        'Acetaminophen Pill',
+        'RXNORM'
     )
 
     src = Record(values, fields)
     res = _to_json(src)
     ok_(res[0])
+
+
+def test_to_system():
+    """Checks that an sab is correctly converted into a system"""
+    sab = 'rxnorm'
+    res = _to_system(sab)
+    exp = 'http://www.nlm.nih.gov/research/umls/rxnorm'
+    eq_(exp, res)

--- a/tests/rxnorm_test.py
+++ b/tests/rxnorm_test.py
@@ -24,9 +24,9 @@ def test_service_uri_requires_scheme_file():
 
 def test_to_relationship():
     """Checks that a record is properly converted to a Relationship"""
-    fields = ['source.CODE', 'source.STR', 'source.SAB',
-              'target.CODE', 'target.STR', 'target.SAB']
+    fields = ['REL', 'source.CODE', 'source.STR', 'source.SAB', 'target.CODE', 'target.STR', 'target.SAB']
     values = (
+        'RB',
         '313782',
         'Acetaminophen 325 MG Oral Tablet',
         'RXNORM',
@@ -58,9 +58,9 @@ def test_to_relationship():
 def test_to_json():
     """Checks that a record is properly converted to .json"""
 
-    fields = ['source.CODE', 'source.STR', 'source.SAB',
-              'target.CODE', 'target.STR', 'target.SAB']
+    fields = ['REL', 'source.CODE', 'source.STR', 'source.SAB', 'target.CODE', 'target.STR', 'target.SAB']
     values = (
+        'RB',
         '313782',
         'Acetaminophen 325 MG Oral Tablet',
         'RXNORM',
@@ -71,8 +71,7 @@ def test_to_json():
 
     src = Record(values, fields)
     res = _to_json(src)
-    print(res)
-    ok_(False)
+    ok_(res)
 
 
 def test_to_system():


### PR DESCRIPTION
Adds support for all additional vocabularies and adds options for suppress flags.

Example:
```
python -m termlink rxnorm file://... -v SNOMEDCT_US -s Y
```

This will include RXNORM and SNOMEDCT_US mappings in the output where the suppress flag is 'N' or 'Y'.