### PR TITLE
Adds support for FHIR CodeSystem resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Adds a new sub-command: `code-system`
+
 ### Changed
 
 - Alters the output format for the `common` sub-command to JSON Lines

--- a/termlink/__main__.py
+++ b/termlink/__main__.py
@@ -7,6 +7,7 @@ import textwrap
 
 from termlink import common
 from termlink import gsea
+from termlink import codesystem
 
 from termlink.configuration import Config
 
@@ -194,6 +195,26 @@ parser_snomedct.add_argument(
 )
 
 parser_snomedct.set_defaults(execute=SnomedCtCommand.execute)
+
+parser_codesystem = subparsers.add_parser(
+    "code-system",
+    help="Convert a FHIR CodeSystem Resource",
+    description="""
+    The CodeSystem resource is used to declare the existence of and describe a code system or code system supplement and its key properties, and optionally define a part or all of its content.
+    """,
+    epilog="""
+    [1] “4.8 Resource CodeSystem - Content.” CodeSystem - FHIR v4.0.0, Retrieved June 5, 2019 from www.hl7.org/fhir/codesystem.html.
+    """
+)
+
+parser_codesystem.add_argument(
+    "uri",
+    metavar="URI",
+    help="resource identifier for files"
+)
+
+parser_codesystem.set_defaults(execute=codesystem.execute)
+
 
 args = parser.parse_args()
 

--- a/termlink/codesystem.py
+++ b/termlink/codesystem.py
@@ -1,0 +1,71 @@
+"""Handles FHIR CodeSystem Resource conversion.
+
+
+This modules provides methods to extract, transform and load relationship
+defined by a FHIR CodeSystem resource.
+
+Various FHIR CodeSystems are available at https://www.hl7.org/fhir/codesystem.html
+"""
+
+import json
+
+from urllib.parse import urlparse
+
+from termlink.models import Coding, Relationship, RelationshipSchema
+
+def _get_relationships(content):
+    '''Extracts concept relationships from a CodeSystem
+
+    Args:
+        content: a dict of a CodeSystem
+
+    Returns:
+        yields relationships
+    '''
+    
+    system = content['url']
+    version = content['version']
+
+    sources = content['concept']
+    targets = [sources[-1]] + sources[0:-1]
+    for source, target in zip(sources, targets):
+        
+        source = Coding(
+            system=system,
+            version=version,
+            code=source['code'],
+            display=source['display']
+        )
+
+        target = Coding(
+            system=system,
+            version=version,
+            code=target['code'],
+            display=target['display']
+        )
+
+        yield Relationship('disjoint', source, target)
+
+def execute(args):
+    '''Converts a FHIR CodeSystem Resource
+
+    Args:
+        args:   command line arguments from argparse
+    '''
+    uri = urlparse(args.uri)
+    if uri.scheme != 'file':
+        raise ValueError(f"uri.scheme '{uri.scheme}' is not supported")
+
+    with open(uri.path) as f:
+        content = json.load(f)
+
+    schema = RelationshipSchema()
+    relationships = _get_relationships(content)
+    serialized = [json.dumps(schema.dump(r)) for r in relationships]
+
+    for o in serialized:
+        print(o)
+
+    return serialized
+
+    

--- a/tests/codesystem_test.py
+++ b/tests/codesystem_test.py
@@ -1,0 +1,24 @@
+"""Verifies the 'codesystem.py' module"""
+
+from argparse import Namespace
+
+import pkg_resources
+
+from nose.tools import eq_, ok_, raises
+
+from pronto import Term
+
+from termlink.codesystem import _get_relationships, execute
+from termlink.models import Coding, Relationship
+
+@raises(ValueError)
+def test_uri_scheme():
+    """An unsupported URI scheme throws a ValueError"""
+    execute(Namespace(uri='foo://bar'))
+
+def test_json_format():
+    """Tests the conversion of an .json file"""
+    path = pkg_resources.resource_filename(__name__, "resources/codesystem.json")
+    uri = f"file://{path}"
+    output = execute(Namespace(uri=uri))
+    ok_(len(output) > 0)

--- a/tests/resources/codesystem.json
+++ b/tests/resources/codesystem.json
@@ -1,0 +1,95 @@
+{
+  "resourceType": "CodeSystem",
+  "id": "example",
+  "meta": {
+    "profile": [
+      "http://hl7.org/fhir/StructureDefinition/shareablecodesystem"
+    ]
+  },
+  "text": {
+    "status": "generated",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n      <p>CodeSystem &quot;ACME Codes for Cholesterol&quot;: This is an example code system that includes \n        all the codes for serum cholesterol defined by ACME inc.</p>\n      <p>Developed by: FHIR project team (example)</p>\n      <p>Published for testing on 28-Jan 2016</p>\n      <p>This code system defines all the ACME codes for serum cholesterol:</p>\n      <table class=\"grid\">\n        <tr>\n          <td>\n            <b>Code</b>\n          </td>\n          <td>\n            <b>Display</b>\n          </td>\n          <td>\n            <b>Definition</b>\n          </td>\n        </tr>\n        <tr>\n          <td>chol-mmol</td>\n          <td>SChol (mmol/L)</td>\n          <td>Serum Cholesterol, in mmol/L</td>\n        </tr>\n        <tr>\n          <td>chol-mass</td>\n          <td>SChol (mg/L)</td>\n          <td>Serum Cholesterol, in mg/L</td>\n        </tr>\n        <tr>\n          <td>chol</td>\n          <td>SChol</td>\n          <td>Serum Cholesterol</td>\n        </tr>\n      </table>\n    </div>"
+  },
+  "url": "http://hl7.org/fhir/CodeSystem/example",
+  "identifier": [
+    {
+      "system": "http://acme.com/identifiers/codesystems",
+      "value": "internal-cholesterol-inl"
+    }
+  ],
+  "version": "20160128",
+  "name": "ACMECholCodesBlood",
+  "title": "ACME Codes for Cholesterol in Serum/Plasma",
+  "status": "draft",
+  "experimental": true,
+  "date": "2016-01-28",
+  "publisher": "Acme Co",
+  "contact": [
+    {
+      "name": "FHIR project team",
+      "telecom": [
+        {
+          "system": "url",
+          "value": "http://hl7.org/fhir"
+        }
+      ]
+    }
+  ],
+  "description": "This is an example code system that includes all the ACME codes for serum/plasma cholesterol from v2.36.",
+  "caseSensitive": true,
+  "content": "complete",
+  "filter": [
+    {
+      "code": "acme-plasma",
+      "description": "An internal filter used to select codes that are only used with plasma",
+      "operator": [
+        "="
+      ],
+      "value": "the value of this filter is either 'true' or 'false'"
+    }
+  ],
+  "concept": [
+    {
+      "code": "chol-mmol",
+      "display": "SChol (mmol/L)",
+      "definition": "Serum Cholesterol, in mmol/L",
+      "designation": [
+        {
+          "use": {
+            "system": "http://acme.com/config/fhir/codesystems/internal",
+            "code": "internal-label"
+          },
+          "value": "From ACME POC Testing"
+        }
+      ]
+    },
+    {
+      "code": "chol-mass",
+      "display": "SChol (mg/L)",
+      "definition": "Serum Cholesterol, in mg/L",
+      "designation": [
+        {
+          "use": {
+            "system": "http://acme.com/config/fhir/codesystems/internal",
+            "code": "internal-label"
+          },
+          "value": "From Paragon Labs"
+        }
+      ]
+    },
+    {
+      "code": "chol",
+      "display": "SChol",
+      "definition": "Serum Cholesterol",
+      "designation": [
+        {
+          "use": {
+            "system": "http://acme.com/config/fhir/codesystems/internal",
+            "code": "internal-label"
+          },
+          "value": "Obdurate Labs uses this with both kinds of units..."
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
```
(venv) λ ~/Projects/termlink/ code-systems python -m termlink code-system -h
usage: __main__.py code-system [-h] URI

The CodeSystem resource is used to declare the existence of and describe a
code system or code system supplement and its key properties, and optionally
define a part or all of its content.

positional arguments:
  URI         resource identifier for files

optional arguments:
  -h, --help  show this help message and exit

[1] “4.8 Resource CodeSystem - Content.” CodeSystem - FHIR v4.0.0, Retrieved
June 5, 2019 from www.hl7.org/fhir/codesystem.html.
```